### PR TITLE
Async request failures should log debug

### DIFF
--- a/CONFIGURATIONS.md
+++ b/CONFIGURATIONS.md
@@ -20,8 +20,8 @@ Directives
 |maxBufferLen|Set the number of activities to send in batched activities|10|int| |
 |apiTimeout |REST API timeout in milliseconds|1000|int|Milliseconds|
 |connectionTimeout|Connection timeout in milliseconds|1000|int|Milliseconds|
-|maxConnectionsPerRoute|Set the maximum connection per route for risk api requests in the connections pool|20|int| |
-|maxConnections|Set the total maximum connections for risk api client|20|int| |
+|maxConnectionsPerRoute|Set the maximum connection per route for risk api requests in the connections pool|50|int| |
+|maxConnections|Set the total maximum connections for risk api client|200|int| |
 |sendPageActivities|Toggle sending asynchronous page activities|true|Boolean| |
 |serverURL|Set the base url for PerimeterX servers|https://sapi-\<app_id>.perimeterx.net|String| |
 |customLogo|The logo will be displayed at the top div of the the block page. The logo's max-height property would be 150px and width would be set to auto.|null|String| |

--- a/src/main/java/com/perimeterx/http/PXHttpClient.java
+++ b/src/main/java/com/perimeterx/http/PXHttpClient.java
@@ -136,7 +136,7 @@ public class PXHttpClient implements PXClient {
             httpResponse = httpClient.execute(post);
             EntityUtils.consume(httpResponse.getEntity());
         } catch (Exception e) {
-            throw new PXException(e);
+            logger.debug("Sending activity failed. Error: {}", e.getMessage());
         } finally {
             if (httpResponse != null) {
                 httpResponse.close();
@@ -160,7 +160,7 @@ public class PXHttpClient implements PXClient {
             basicAsyncResponseConsumer = new BasicAsyncResponseConsumer();
             asyncHttpClient.execute(producer, basicAsyncResponseConsumer, new PxClientAsyncHandler());
         } catch (Exception e) {
-            throw new PXException(e);
+            logger.debug("Sending batch activities failed. Error: {}", e.getMessage());
         } finally {
             if (producer != null) {
                 producer.close();
@@ -217,7 +217,7 @@ public class PXHttpClient implements PXClient {
             basicAsyncResponseConsumer = new BasicAsyncResponseConsumer();
             asyncHttpClient.execute(producer, basicAsyncResponseConsumer, new PxClientAsyncHandler());
         } catch (Exception e) {
-            e.printStackTrace();
+            logger.debug("Sending telemetry failed. Error: {}", e.getMessage());
         } finally {
             if (producer != null) {
                 producer.close();

--- a/src/main/java/com/perimeterx/models/configuration/PXConfiguration.java
+++ b/src/main/java/com/perimeterx/models/configuration/PXConfiguration.java
@@ -340,7 +340,7 @@ public class PXConfiguration {
         private ModuleMode moduleMode = ModuleMode.MONITOR;
         private int remoteConfigurationInterval = 1000 * 5;
         private int remoteConfigurationDelay = 0;
-        private int maxConnectionsPerRoute = 20;
+        private int maxConnectionsPerRoute = 50;
         private int maxConnections = 200;
         private String remoteConfigurationUrl = Constants.REMOTE_CONFIGURATION_SERVER_URL;
         private Set<String> ipHeaders = new HashSet<>();

--- a/src/main/java/com/perimeterx/utils/PXCommonUtils.java
+++ b/src/main/java/com/perimeterx/utils/PXCommonUtils.java
@@ -24,7 +24,8 @@ public class PXCommonUtils {
     public static RequestConfig getRequestConfig(PXConfiguration pxConfiguration) {
         RequestConfig.Builder requestConfigBuilder = RequestConfig.custom()
                 .setConnectTimeout(pxConfiguration.getConnectionTimeout())
-                .setConnectionRequestTimeout(pxConfiguration.getApiTimeout());
+                .setConnectionRequestTimeout(pxConfiguration.getApiTimeout())
+                .setSocketTimeout(pxConfiguration.getApiTimeout());
         if (pxConfiguration.shouldUseProxy()) {
             HttpHost proxy = new HttpHost(pxConfiguration.getProxyHost(), pxConfiguration.getProxyPort());
             requestConfigBuilder.setProxy(proxy);


### PR DESCRIPTION
[CHANGE] when async request fails, log debug instead of throwing an exception.
[CHANGE] maxConnectionsPerRoute to 50.
[ADD] socket connection timeout.