### PR TITLE
Update dependencies Versions to avoid security vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>com.github.spullara.mustache.java</groupId>
             <artifactId>compiler</artifactId>
-            <version>0.9.6</version>
+            <version>0.9.7</version>
             <!-- dont update version until deprecating djk7 -->
         </dependency>
 
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.3</version>
+            <version>2.11.4</version>
         </dependency>
 
         <dependency>
@@ -144,13 +144,25 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.8.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.15</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.9</version>
+            <version>3.12.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>3.3.0</version>
         </dependency>
 
         <dependency>
@@ -163,6 +175,12 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpasyncclient</artifactId>
             <version>4.1.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.13</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
commons-io:commons-io : 2.6 -->	2.8.0
com.fasterxml.jackson.core:jackson-databind: 2.10.5.1--> 2.11.4
org.apache.commons:commons-lang3: 3.9 --> 3.12.0
com.github.spullara.mustache.java:compiler: 0.9.6--> 0.9.7
org.codehaus.plexus:plexus-utils:	3.0.20-->	3.3.0
commons-codec:commons-codec: 1.10--> 1.15
org.apache.httpcomponents:httpclient:	4.5.6--> 4.5.13