### PR TITLE
PR: Update Documentation in Repo to point towards updated 6.2.5 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # [PerimeterX](http://www.perimeterx.com) Java SDK
 
-> Latest stable version: [v6.2.4](https://search.maven.org/#artifactdetails%7Ccom.perimeterx%7Cperimeterx-sdk%7C6.2.4%7Cjar)
+> Latest stable version: [v6.2.5](https://search.maven.org/artifact/com.perimeterx/perimeterx-sdk/6.2.5/jar)
 
 ## Table of Contents
 


### PR DESCRIPTION
Also suggest freezing a new release commit after this fix to show that we recognise v6.2.5 as a significant sub-version.