### PR TITLE
SDKNEW-1865/bug - enable setting simulated_block before sending block activity

### DIFF
--- a/src/main/java/com/perimeterx/api/additionalContext/credentialsIntelligence/protocol/V2CIProtocol.java
+++ b/src/main/java/com/perimeterx/api/additionalContext/credentialsIntelligence/protocol/V2CIProtocol.java
@@ -17,10 +17,11 @@ public class V2CIProtocol implements CredentialsIntelligenceProtocol {
         final String rawUsername = credentials.getUsername();
         final String normalizedUsername = isValid(rawUsername) ?
                 getV2NormalizedEmailAddress(rawUsername) : rawUsername;
+        final String encodedUsername = encodeString(normalizedUsername, HashAlgorithm.SHA256);
 
         return new UserLoginData(
-                getEncodedV2Password(normalizedUsername, credentials.getPassword()),
-                encodeString(normalizedUsername, HashAlgorithm.SHA256),
+                getEncodedV2Password(encodedUsername, credentials.getPassword()),
+                encodedUsername,
                 rawUsername,
                 CIProtocol.V2,
                 null
@@ -43,8 +44,7 @@ public class V2CIProtocol implements CredentialsIntelligenceProtocol {
         return username + domain;
     }
 
-    private String getEncodedV2Password(String normalizedUsername, String password) {
-        final String encodedUserName = encodeString(normalizedUsername, SHA256);
+    private String getEncodedV2Password(String encodedUserName, String password) {
         final String encodedPassword = encodeString(password, SHA256);
 
         return encodeString(encodedUserName + encodedPassword, SHA256);

--- a/src/main/java/com/perimeterx/api/blockhandler/DefaultBlockHandler.java
+++ b/src/main/java/com/perimeterx/api/blockhandler/DefaultBlockHandler.java
@@ -52,7 +52,7 @@ public class DefaultBlockHandler implements BlockHandler {
         }
     }
 
-    private void sendMessage(String blockPageResponse, HttpServletResponseWrapper responseWrapper, PXContext context, PXConfiguration pxConfig) throws PXException, IOException {
+    protected void sendMessage(String blockPageResponse, HttpServletResponseWrapper responseWrapper, PXContext context, PXConfiguration pxConfig) throws PXException, IOException {
         if (context.getBlockAction() == BlockAction.RATE) {
             responseWrapper.setStatus(429);
         } else {
@@ -126,7 +126,7 @@ public class DefaultBlockHandler implements BlockHandler {
         }
     }
 
-    private String getPage(Map<String, String> props, String filePrefix) throws PXException {
+    protected String getPage(Map<String, String> props, String filePrefix) throws PXException {
 
         String template = filePrefix + Constants.FILE_EXTENSION_MUSTACHE;
         return TemplateFactory.getTemplate(template, props);

--- a/src/main/java/com/perimeterx/models/PXContext.java
+++ b/src/main/java/com/perimeterx/models/PXContext.java
@@ -208,7 +208,6 @@ public class PXContext {
     private boolean isMonitoredRequest;
     private AdditionalContext additionalContext;
     private UUID requestId;
-    private boolean simulatedBlock;
 
     public PXContext(final HttpServletRequest request, final IPProvider ipProvider, final HostnameProvider hostnameProvider, PXConfiguration pxConfiguration) {
         this.pxConfiguration = pxConfiguration;
@@ -241,8 +240,6 @@ public class PXContext {
         this.httpMethod = request.getMethod();
         this.isMonitoredRequest = !shouldBypassMonitor() && shouldMonitorRequest();
         this.requestId = UUID.randomUUID();
-        this.simulatedBlock = this.isMonitoredRequest;
-
 
         String protocolDetails[] = request.getProtocol().split("/");
         this.httpVersion = protocolDetails.length > 1 ? protocolDetails[1] : StringUtils.EMPTY;

--- a/src/main/java/com/perimeterx/models/PXContext.java
+++ b/src/main/java/com/perimeterx/models/PXContext.java
@@ -208,6 +208,7 @@ public class PXContext {
     private boolean isMonitoredRequest;
     private AdditionalContext additionalContext;
     private UUID requestId;
+    private boolean simulatedBlock;
 
     public PXContext(final HttpServletRequest request, final IPProvider ipProvider, final HostnameProvider hostnameProvider, PXConfiguration pxConfiguration) {
         this.pxConfiguration = pxConfiguration;
@@ -240,6 +241,7 @@ public class PXContext {
         this.httpMethod = request.getMethod();
         this.isMonitoredRequest = !shouldBypassMonitor() && shouldMonitorRequest();
         this.requestId = UUID.randomUUID();
+        this.simulatedBlock = this.isMonitoredRequest;
 
 
         String protocolDetails[] = request.getProtocol().split("/");

--- a/src/main/java/com/perimeterx/models/activities/BlockActivityDetails.java
+++ b/src/main/java/com/perimeterx/models/activities/BlockActivityDetails.java
@@ -65,7 +65,7 @@ public class BlockActivityDetails extends CommonActivityDetails {
         this.riskRtt = context.getRiskRtt();
         this.cookieOrigin = context.getCookieOrigin();
         this.moduleVersion = Constants.SDK_VERSION;
-        this.simulatedBlock = context.isSimulatedBlock();
+        this.simulatedBlock = context.isMonitoredRequest();
         this.customParameters = context.getCustomParameters();
 
         if (context.getBlockAction() != null) {

--- a/src/main/java/com/perimeterx/models/activities/BlockActivityDetails.java
+++ b/src/main/java/com/perimeterx/models/activities/BlockActivityDetails.java
@@ -65,7 +65,7 @@ public class BlockActivityDetails extends CommonActivityDetails {
         this.riskRtt = context.getRiskRtt();
         this.cookieOrigin = context.getCookieOrigin();
         this.moduleVersion = Constants.SDK_VERSION;
-        this.simulatedBlock = context.isMonitoredRequest();
+        this.simulatedBlock = context.isSimulatedBlock();
         this.customParameters = context.getCustomParameters();
 
         if (context.getBlockAction() != null) {

--- a/src/test/java/com/perimeterx/api/DefaultVerificationHandlerTest.java
+++ b/src/test/java/com/perimeterx/api/DefaultVerificationHandlerTest.java
@@ -95,7 +95,7 @@ public class DefaultVerificationHandlerTest {
     }
 
     @Test
-    public void TestIsActivityContainsSimulatedBlockUpdatedValue() throws PXException, IOException {
+    public void TestIsBlockHandlerIsPreviousToActivityHandlers() throws PXException, IOException {
         config = PXConfiguration.builder()
                 .appId("appId")
                 .authToken("token")

--- a/src/test/java/com/perimeterx/api/DefaultVerificationHandlerTest.java
+++ b/src/test/java/com/perimeterx/api/DefaultVerificationHandlerTest.java
@@ -32,6 +32,8 @@ public class DefaultVerificationHandlerTest {
     private PXConfiguration config;
     private DefaultVerificationHandler defaultVerificationHandler;
     private BlockHandler blockHandler;
+    private HttpServletRequest request;
+    private HttpServletResponseWrapper response;
 
     @BeforeMethod
     public void setUp() {
@@ -43,7 +45,9 @@ public class DefaultVerificationHandlerTest {
                 .remoteConfigurationEnabled(false)
                 .blockingScore(30)
                 .bypassMonitorHeader("TEST-BYPASS")
-                .build();;
+                .build();
+        this.request = new MockHttpServletRequest();
+        this.response = new HttpServletResponseWrapper(new MockHttpServletResponse());
         PXClient pxClient = TestObjectUtils.blockingPXClient(config.getBlockingScore());
         this.activityHandler = new DefaultActivityHandler(pxClient, config);
         this.hostnameProvider = new DefaultHostnameProvider();
@@ -53,7 +57,6 @@ public class DefaultVerificationHandlerTest {
 
     @Test
     public void TestMonitorModeBypass() throws PXException {
-        HttpServletRequest request = new MockHttpServletRequest();
         ((MockHttpServletRequest) request).addHeader("TEST-BYPASS", "1");
         HttpServletResponseWrapper response = new HttpServletResponseWrapper(new MockHttpServletResponse());
         PXContext context = new PXContext(request, ipProvider, hostnameProvider, config);
@@ -66,9 +69,7 @@ public class DefaultVerificationHandlerTest {
 
     @Test
     public void TestMonitorModeBypassWrongValueInHeader() throws PXException {
-        HttpServletRequest request = new MockHttpServletRequest();
         ((MockHttpServletRequest) request).addHeader("TEST-BYPASS", "0");
-        HttpServletResponseWrapper response = new HttpServletResponseWrapper(new MockHttpServletResponse());
         PXContext context = new PXContext(request, ipProvider, hostnameProvider, config);
         context.setRiskScore(100);
         DefaultVerificationHandler defaultVerificationHandler = new DefaultVerificationHandler(config, activityHandler);
@@ -79,7 +80,6 @@ public class DefaultVerificationHandlerTest {
 
     @Test
     public void TestMonitorModeBypassHeaderDefinedAndMissingFromRequest() throws PXException {
-        HttpServletRequest request = new MockHttpServletRequest();
         HttpServletResponseWrapper response = new HttpServletResponseWrapper(new MockHttpServletResponse());
         PXContext context = new PXContext(request, ipProvider, hostnameProvider, config);
         context.setRiskScore(100);
@@ -88,5 +88,4 @@ public class DefaultVerificationHandlerTest {
         boolean verified = defaultVerificationHandler.handleVerification(context, response);
         Assert.assertTrue(verified);
     }
-
 }

--- a/src/test/java/com/perimeterx/api/DefaultVerificationHandlerTest.java
+++ b/src/test/java/com/perimeterx/api/DefaultVerificationHandlerTest.java
@@ -21,7 +21,6 @@ import testutils.TestObjectUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponseWrapper;
-import java.io.IOException;
 
 
 @Test
@@ -36,7 +35,15 @@ public class DefaultVerificationHandlerTest {
 
     @BeforeMethod
     public void setUp() {
-        config = TestObjectUtils.generateConfiguration();
+        this.config = PXConfiguration.builder()
+                .appId("appId")
+                .authToken("token")
+                .cookieKey("cookieKey")
+                .moduleMode(ModuleMode.MONITOR)
+                .remoteConfigurationEnabled(false)
+                .blockingScore(30)
+                .bypassMonitorHeader("TEST-BYPASS")
+                .build();;
         PXClient pxClient = TestObjectUtils.blockingPXClient(config.getBlockingScore());
         this.activityHandler = new DefaultActivityHandler(pxClient, config);
         this.hostnameProvider = new DefaultHostnameProvider();
@@ -45,16 +52,7 @@ public class DefaultVerificationHandlerTest {
     }
 
     @Test
-    public void TestMonitorModeBypass() throws IOException, PXException {
-        PXConfiguration config = PXConfiguration.builder()
-                .appId("appId")
-                .authToken("token")
-                .cookieKey("cookieKey")
-                .moduleMode(ModuleMode.MONITOR)
-                .remoteConfigurationEnabled(false)
-                .blockingScore(30)
-                .bypassMonitorHeader("TEST-BYPASS")
-                .build();
+    public void TestMonitorModeBypass() throws PXException {
         HttpServletRequest request = new MockHttpServletRequest();
         ((MockHttpServletRequest) request).addHeader("TEST-BYPASS", "1");
         HttpServletResponseWrapper response = new HttpServletResponseWrapper(new MockHttpServletResponse());
@@ -67,16 +65,7 @@ public class DefaultVerificationHandlerTest {
     }
 
     @Test
-    public void TestMonitorModeBypassWrongValueInHeader() throws IOException, PXException {
-        PXConfiguration config = PXConfiguration.builder()
-                .appId("appId")
-                .authToken("token")
-                .cookieKey("cookieKey")
-                .moduleMode(ModuleMode.MONITOR)
-                .remoteConfigurationEnabled(false)
-                .blockingScore(30)
-                .bypassMonitorHeader("TEST-BYPASS")
-                .build();
+    public void TestMonitorModeBypassWrongValueInHeader() throws PXException {
         HttpServletRequest request = new MockHttpServletRequest();
         ((MockHttpServletRequest) request).addHeader("TEST-BYPASS", "0");
         HttpServletResponseWrapper response = new HttpServletResponseWrapper(new MockHttpServletResponse());
@@ -89,16 +78,7 @@ public class DefaultVerificationHandlerTest {
     }
 
     @Test
-    public void TestMonitorModeBypassHeaderDefinedAndMissingFromRequest() throws IOException, PXException {
-        PXConfiguration config = PXConfiguration.builder()
-                .appId("appId")
-                .authToken("token")
-                .cookieKey("cookieKey")
-                .moduleMode(ModuleMode.MONITOR)
-                .remoteConfigurationEnabled(false)
-                .blockingScore(30)
-                .bypassMonitorHeader("TEST-BYPASS")
-                .build();
+    public void TestMonitorModeBypassHeaderDefinedAndMissingFromRequest() throws PXException {
         HttpServletRequest request = new MockHttpServletRequest();
         HttpServletResponseWrapper response = new HttpServletResponseWrapper(new MockHttpServletResponse());
         PXContext context = new PXContext(request, ipProvider, hostnameProvider, config);

--- a/src/test/java/com/perimeterx/api/DefaultVerificationHandlerTest.java
+++ b/src/test/java/com/perimeterx/api/DefaultVerificationHandlerTest.java
@@ -9,18 +9,26 @@ import com.perimeterx.api.providers.RemoteAddressIPProvider;
 import com.perimeterx.api.verificationhandler.DefaultVerificationHandler;
 import com.perimeterx.http.PXClient;
 import com.perimeterx.models.PXContext;
+import com.perimeterx.models.activities.Activity;
+import com.perimeterx.models.activities.BlockActivityDetails;
 import com.perimeterx.models.configuration.ModuleMode;
 import com.perimeterx.models.configuration.PXConfiguration;
 import com.perimeterx.models.exceptions.PXException;
+import org.mockito.ArgumentCaptor;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import testutils.CustomBlockHandler;
 import testutils.TestObjectUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponseWrapper;
+import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 
 @Test
@@ -41,9 +49,6 @@ public class DefaultVerificationHandlerTest {
                 .appId("appId")
                 .authToken("token")
                 .cookieKey("cookieKey")
-                .moduleMode(ModuleMode.MONITOR)
-                .remoteConfigurationEnabled(false)
-                .blockingScore(30)
                 .bypassMonitorHeader("TEST-BYPASS")
                 .build();
         this.request = new MockHttpServletRequest();
@@ -87,5 +92,30 @@ public class DefaultVerificationHandlerTest {
         context.setBlockAction("b");
         boolean verified = defaultVerificationHandler.handleVerification(context, response);
         Assert.assertTrue(verified);
+    }
+
+    @Test
+    public void TestIsActivityContainsSimulatedBlockUpdatedValue() throws PXException, IOException {
+        config = PXConfiguration.builder()
+                .appId("appId")
+                .authToken("token")
+                .cookieKey("cookieKey")
+                .moduleMode(ModuleMode.BLOCKING)
+                .blockHandler(new CustomBlockHandler())
+                .build();
+        final HttpServletResponseWrapper response = new HttpServletResponseWrapper(new MockHttpServletResponse());
+        final PXContext context = new PXContext(request, ipProvider, hostnameProvider, config);
+        context.setRiskScore(100);
+        context.setBlockAction("b");
+
+        final PXClient pxClient = mock(PXClient.class);
+        activityHandler = new DefaultActivityHandler(pxClient, config);
+        final DefaultVerificationHandler defaultVerificationHandler = new DefaultVerificationHandler(config, activityHandler);
+
+        defaultVerificationHandler.handleVerification(context, response);
+        final ArgumentCaptor<Activity> captor = ArgumentCaptor.forClass(Activity.class);
+        verify(pxClient).sendActivity(captor.capture());
+
+        Assert.assertTrue((((BlockActivityDetails) captor.getValue().getDetails()).getSimulatedBlock()));
     }
 }

--- a/src/test/java/testutils/CustomBlockHandler.java
+++ b/src/test/java/testutils/CustomBlockHandler.java
@@ -38,7 +38,7 @@ public class CustomBlockHandler extends DefaultBlockHandler {
         }
         try {
             sendMessage(blockPageResponse, responseWrapper, context, pxConfig);
-            context.setSimulatedBlock(true); // This row is an example of how a client is used the custom class to modify the context state
+            context.setMonitoredRequest(true); // This row is an example of how a client is used the custom class to modify the context state
         } catch (IOException e) {
             throw new PXException(e);
         }

--- a/src/test/java/testutils/CustomBlockHandler.java
+++ b/src/test/java/testutils/CustomBlockHandler.java
@@ -1,0 +1,46 @@
+package testutils;
+
+import com.perimeterx.api.blockhandler.DefaultBlockHandler;
+import com.perimeterx.api.blockhandler.templates.TemplateFactory;
+import com.perimeterx.models.PXContext;
+import com.perimeterx.models.configuration.PXConfiguration;
+import com.perimeterx.models.exceptions.PXException;
+import com.perimeterx.utils.Constants;
+
+import javax.servlet.http.HttpServletResponseWrapper;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CustomBlockHandler extends DefaultBlockHandler {
+
+    @Override
+    public void handleBlocking(PXContext context, PXConfiguration pxConfig, HttpServletResponseWrapper responseWrapper) throws PXException {
+        Map<String, String> props = new HashMap<>();
+        String filePrefix;
+        String blockPageResponse;
+        switch (context.getBlockAction()) {
+            case RATE:
+                filePrefix = Constants.RATELIMIT_TEMPLATE;
+                blockPageResponse = getPage(props, filePrefix);
+                break;
+
+            case CHALLENGE:
+                String actionData = context.getBlockActionData();
+                if (actionData != null) {
+                    blockPageResponse = actionData;
+                    break;
+                }
+            default:
+                filePrefix = Constants.CAPTCHA_BLOCK_TEMPLATE;
+                props = TemplateFactory.getProps(context, pxConfig);
+                blockPageResponse = getPage(props, filePrefix);
+        }
+        try {
+            sendMessage(blockPageResponse, responseWrapper, context, pxConfig);
+            context.setSimulatedBlock(true); // This row is an example of how a client is used the custom class to modify the context state
+        } catch (IOException e) {
+            throw new PXException(e);
+        }
+    }
+}


### PR DESCRIPTION
When trying to set the  simulated_block property in the context via customBlockHandler - handleBlocking it will not affect the blocking activity.
This PR fixing it.