### PR TITLE
Adding an option to close PerimeterX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change Log
 ## [vX.X.X](...)
 - Updating readme with `customIsSensitve`, `customParametersExtraction`
-- Added an option to configure logger without slf4j using `PXConfiguration.setPxLoggerSeverity(<loggerSeverity>)` 
+- Added an option to configure logger without slf4j using `PXConfiguration.setPxLoggerSeverity(<loggerSeverity>)`
+- Added an option to close PerimeterX [SDKNEW-2781](https://perimeterx.atlassian.net/browse/SDKNEW-2781)
 
 ## [v6.5.0](https://github.com/PerimeterX/perimeterx-java-sdk/compare/v6.5.0...HEAD) (2023-03-04)
 - Adding custom is sensitive configuration option

--- a/src/main/java/com/perimeterx/api/PerimeterX.java
+++ b/src/main/java/com/perimeterx/api/PerimeterX.java
@@ -61,13 +61,12 @@ import com.perimeterx.utils.StringUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponseWrapper;
+import java.io.Closeable;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
 import java.util.Base64;
-import java.util.Optional;
 
 import static com.perimeterx.utils.Constants.*;
 import static java.util.Objects.isNull;
@@ -78,7 +77,7 @@ import static java.util.Objects.isNull;
  * Created by shikloshi on 03/07/2016.
  */
 
-public class PerimeterX {
+public class PerimeterX implements Closeable {
 
     private static final PXLogger logger = PXLogger.getLogger(PerimeterX.class);
 
@@ -90,6 +89,7 @@ public class PerimeterX {
     private HostnameProvider hostnameProvider;
     private VerificationHandler verificationHandler;
     private ReverseProxy reverseProxy;
+    private PXHttpClient pxClient = null;
 
     private void init(PXConfiguration configuration) throws PXException {
         logger.debug(PXLogger.LogReason.DEBUG_INITIALIZING_MODULE);
@@ -97,7 +97,7 @@ public class PerimeterX {
         this.configuration = configuration;
         hostnameProvider = new DefaultHostnameProvider();
         ipProvider = new CombinedIPProvider(configuration);
-        PXHttpClient pxClient = new PXHttpClient(configuration);
+        this.pxClient = new PXHttpClient(configuration);
         this.activityHandler = new BufferedActivityHandler(pxClient, this.configuration);
 
         if (configuration.isRemoteConfigurationEnabled()) {
@@ -337,4 +337,10 @@ public class PerimeterX {
         this.verificationHandler = verificationHandler;
     }
 
+    @Override
+    public void close() throws IOException {
+        if(this.pxClient != null) {
+            this.pxClient.close();
+        }
+    }
 }

--- a/src/main/java/com/perimeterx/http/TimerValidateRequestsQueue.java
+++ b/src/main/java/com/perimeterx/http/TimerValidateRequestsQueue.java
@@ -4,13 +4,15 @@ import com.perimeterx.models.configuration.PXConfiguration;
 import com.perimeterx.utils.PXLogger;
 import org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager;
 
+import java.io.Closeable;
 import java.util.Timer;
 import java.util.TimerTask;
 
-public class TimerValidateRequestsQueue extends TimerTask {
+public class TimerValidateRequestsQueue extends TimerTask implements Closeable {
 
     private static final PXLogger logger = PXLogger.getLogger(TimerValidateRequestsQueue.class);
 
+    private Timer timer = null;
     private PoolingNHttpClientConnectionManager nHttpConnectionManager;
     private PXConfiguration pxConfiguration;
 
@@ -29,7 +31,16 @@ public class TimerValidateRequestsQueue extends TimerTask {
      * Sets a new timer object and runs its execution method
      */
     public void schedule() {
-        Timer timer = new Timer();
+        this.close();
+        timer = new Timer();
         timer.schedule(this, 0, pxConfiguration.getValidateRequestQueueInterval());
+    }
+
+    @Override
+    public void close() {
+        if(timer != null) {
+            timer.cancel();
+            timer = null;
+        }
     }
 }

--- a/web/src/main/java/com/web/PXFilter.java
+++ b/web/src/main/java/com/web/PXFilter.java
@@ -54,6 +54,10 @@ public class PXFilter implements Filter {
 
     @Override
     public void destroy() {
-
+        try {
+            pxFilter.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 }


### PR DESCRIPTION
This PR should solve the issue: #121

To properly close the resources use `pxFilter.close()` as shown in the example.

